### PR TITLE
Handle parsing and runner errors gracefully.

### DIFF
--- a/app/controllers/results_controller.rb
+++ b/app/controllers/results_controller.rb
@@ -1,4 +1,6 @@
 class ResultsController < ApplicationController
+  rescue_from Runner::RunnerError, with: :runner_error
+
   def index
     url = URL.new(params[:url])
     if url.valid?
@@ -8,5 +10,13 @@ class ResultsController < ApplicationController
       flash.now[:error] = url.error
       @report = EmptyReport.new
     end
+  end
+
+  private
+
+  def runner_error
+    flash.now[:error] = t("runner.error")
+    @report = EmptyReport.new
+    render :index
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -39,3 +39,5 @@ en:
     errors:
       blank: URL cannot be blank
       invalid: This URL is invalid
+  runner:
+    error: Could not load that URL

--- a/lib/report_loader.rb
+++ b/lib/report_loader.rb
@@ -20,6 +20,6 @@ class ReportLoader
   end
 
   def results_hash
-    JSON.parse(runner.execute, max_nesting: 200)
+    runner.execute
   end
 end

--- a/lib/runner.rb
+++ b/lib/runner.rb
@@ -1,4 +1,6 @@
 class Runner
+  class RunnerError < StandardError; end
+
   RUNNER_PATH = File.expand_path("../../vendor/axs/auditor.js", __FILE__)
 
   def initialize(url)
@@ -6,7 +8,17 @@ class Runner
   end
 
   def execute
-    raw_results
+    JSON.parse(raw_results, max_nesting: 200)
+  rescue JSON::ParserError => e
+    Honeybadger.notify(
+      error_class: "JSON::ParserError",
+      error_message: "JSON::ParserError: #{e.message}",
+      parameters: {
+        url: @url,
+        body: raw_results
+      }
+    )
+    raise RunnerError
   end
 
   private

--- a/spec/controllers/results_controller_spec.rb
+++ b/spec/controllers/results_controller_spec.rb
@@ -14,6 +14,17 @@ describe ResultsController do
         expect(response).to be_success
         expect(request.flash.now[:error]).to be_blank
       end
+
+      context "with a runner error" do
+        it "rescues with a flash notice" do
+          allow(Runner).to receive(:new).and_raise(Runner::RunnerError)
+
+          get :index, url: "http://google.com"
+
+          expect(request.flash.now[:error]).not_to be_blank
+          expect(assigns[:report]).to be_a EmptyReport
+        end
+      end
     end
 
     context "with an invalid url" do

--- a/spec/lib/report_loader_spec.rb
+++ b/spec/lib/report_loader_spec.rb
@@ -3,9 +3,9 @@ require "rails_helper"
 describe ReportLoader do
   describe "#report" do
     it "returns a report object" do
-      results = [].to_json
-      auditor = double(:auditor, execute: results)
+      auditor = double(:auditor, execute: [])
       loader = ReportLoader.new(auditor)
+
       expect(loader.report).to be_a Report
     end
   end

--- a/spec/lib/runner_spec.rb
+++ b/spec/lib/runner_spec.rb
@@ -2,13 +2,26 @@ require "rails_helper"
 
 describe Runner do
   describe "#execute" do
-    it "returns JSON" do
+    context "with stringified results" do
+      it "returns JSON" do
+        url = double(:url)
+        runner = Runner.new(url)
+        allow(runner).to receive(:`).and_return([].to_json)
+
+        result = runner.execute
+        expect(result).to eq []
+      end
+    end
+  end
+
+  context "with a phantomjs error message" do
+    it "raises an error" do
       url = double(:url)
       runner = Runner.new(url)
-      allow(runner).to receive(:`).and_return([].to_json)
+      allow(runner).to receive(:`).and_return("Could not parse url")
 
-      result = runner.execute
-      expect(JSON.parse(result)).to eq []
+      expect(Honeybadger).to receive(:notify)
+      expect { runner.execute }.to raise_error(Runner::RunnerError)
     end
   end
 end


### PR DESCRIPTION
- When Phantomjs or Json parsing barfs, show a flash notice.