### PR TITLE
Persist url in form when there is a server error.

### DIFF
--- a/app/controllers/results_controller.rb
+++ b/app/controllers/results_controller.rb
@@ -2,21 +2,30 @@ class ResultsController < ApplicationController
   rescue_from Runner::RunnerError, with: :runner_error
 
   def index
-    url = URL.new(params[:url])
     if url.valid?
       runner = Runner.new(url)
       @report = ReportLoader.new(runner).report
     else
       flash.now[:error] = url.error
-      @report = EmptyReport.new
+      @url = params[:url]
+      render_empty_report
     end
   end
 
   private
 
-  def runner_error
-    flash.now[:error] = t("runner.error")
+  def render_empty_report
     @report = EmptyReport.new
     render :index
+  end
+
+  def runner_error
+    flash.now[:error] = t("runner.error")
+    render_empty_report
+  end
+
+  def url
+    raw_url = params[:url] || ""
+    @url ||= URL.new(raw_url)
   end
 end

--- a/lib/url.rb
+++ b/lib/url.rb
@@ -1,6 +1,6 @@
 class URL
   def initialize(url)
-    @url = url || ''
+    @url = url
   end
 
   def valid?


### PR DESCRIPTION
- It's easier to see why the parsing failed if the url persists in the form.

https://trello.com/c/dlS1mKi1/81-show-the-url-that-was-audited-on-the-results-page